### PR TITLE
Fix frozen lockfile argument to yarn install

### DIFF
--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -16,7 +16,7 @@ patch -p1 </root/Signal-Desktop.patch
 # Build Signal-Desktop
 nvm use
 if [[ "${ARCH}" == "arm64v8" ]]; then export USE_SYSTEM_FPM=true; fi
-yarn install --frozen-lockfileyarn
+yarn install --frozen-lockfile
 yarn generate
 yarn build-release
 


### PR DESCRIPTION
Use the correct argument for instructing `yarn install` to use a frozen lockfile.

See [the yarn install docs](https://classic.yarnpkg.com/lang/en/docs/cli/install/#toc-yarn-install-frozen-lockfile) for more information. 